### PR TITLE
Fix typo in comment for `customLoggingElements` in src/structs.h

### DIFF
--- a/src/structs.h
+++ b/src/structs.h
@@ -62,7 +62,7 @@ struct LoggingConfig {
     std::function<void(int taskID, String msg)> customVerboseAction = [](const int taskID, const String& msg) {};
 
     // Custom LoggingElement-Configurations can be used, to override the default logLevel for matching messages.
-    // Example: You can set the default-logLevel to DEBUG, but teh loglevel vor alle Methods from class "xyz" to VERBOSE
+    // Example: You can set the default-logLevel to DEBUG, but the loglevel for all methods from class "xyz" to VERBOSE
     std::vector<LoggingElement> customLoggingElements;
 };
 


### PR DESCRIPTION
### Motivation
- Clean up an English typo in the inline documentation to improve readability and maintainability of the logging configuration.
- Preserve the original intent of the comment which explains the purpose of `customLoggingElements`.

### Description
- Edited the comment in `src/structs.h` that documents `customLoggingElements` to correct the phrasing.
- Replaced the incorrect fragment with the clearer wording: `the loglevel for all methods` while keeping the example/context intact.
- This is a comment-only change and does not modify program logic or APIs.

### Testing
- No automated tests were run because this change only updates a comment.
- No build or runtime changes were required and therefore no tests failed or succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965713928d8832a9ddfc4e211474da2)