### PR TITLE
Update README to use `.loglevel` and `Loglevel::WARN`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ An easy Logging-Framework for ESP32.
 
 void setup() {
     Serial.begin(115200);
-    Log::init({ .defaultLoglevel = Loglevel::DEBUG });
+    Log::init({ .loglevel = Loglevel::DEBUG });
 }
 
 void loop() {
@@ -67,7 +67,7 @@ void setup() {
     Serial.begin(115200);
     
     /** Init EZLog: */
-    Log::init({ .defaultLoglevel = Loglevel::DEBUG });
+    Log::init({ .loglevel = Loglevel::DEBUG });
 }
 ```
 
@@ -167,6 +167,5 @@ You can find a description of the available logging-methods in the [API Document
 | `Loglevel::VERBOSE` | Extreme detailed information, which is only relevant for debugging. |
 | `Loglevel::DEBUG`   | Detailed information, which is only relevant for debugging.         |
 | `Loglevel::INFO`    | General information about the program flow.                         |
-| `Loglevel::WARNING` | Indicates a potential problem, which is not critical.               |
+| `Loglevel::WARN`    | Indicates a potential problem, which is not critical.               |
 | `Loglevel::ERROR`   | Indicates a critical problem, which should be fixed.                |
-


### PR DESCRIPTION
### Motivation
- The README contained outdated initialization examples using `.defaultLoglevel` and a log-level name `Loglevel::WARNING` that no longer match the current `LoggingConfig` API.
- Aligning documentation with the actual configuration and enum names prevents compile-time confusion and improves usability of the examples.

### Description
- Replaced `Log::init({ .defaultLoglevel = Loglevel::DEBUG })` with `Log::init({ .loglevel = Loglevel::DEBUG })` in `README.md` examples.
- Updated the Log-Levels table entry from `Loglevel::WARNING` to `Loglevel::WARN` in `README.md`.
- This change is documentation-only and modifies only the `README.md` file.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696571337bb8832a8dd302032d1cc0e4)