### PR TITLE
Add EZLog utility tests

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -83,3 +83,13 @@ build_flags = ${common.build_flags}
               ${esp32s3.build_flags}
               ;Optional: Disable Colors: -D EZLOG_DISABLE_COLORS
 build_unflags = ${common.build_unflags}
+
+;—————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
+[env:esp32_test]
+board = ${esp32.board}
+build_flags = ${common.build_flags}
+              ${ezlog.build_flags}
+build_unflags = ${common.build_unflags}
+test_framework = unity
+test_filter = test_log_utils
+test_build_project_src = true

--- a/test/test_log_utils/test_log_utils.cpp
+++ b/test/test_log_utils/test_log_utils.cpp
@@ -1,0 +1,86 @@
+#include <Arduino.h>
+#include <unity.h>
+
+#define private public
+#include "EZLog.h"
+#undef private
+
+void test_split_char_trims_whitespace() {
+    const std::vector<std::string> tokens = EZLog::split("  alpha , beta ,gamma  ", ',');
+    TEST_ASSERT_EQUAL_UINT32(3, tokens.size());
+    TEST_ASSERT_EQUAL_STRING("alpha", tokens[0].c_str());
+    TEST_ASSERT_EQUAL_STRING("beta", tokens[1].c_str());
+    TEST_ASSERT_EQUAL_STRING("gamma", tokens[2].c_str());
+}
+
+void test_split_string_delimiter() {
+    const std::vector<String> tokens = EZLog::split("one::two::three", "::");
+    TEST_ASSERT_EQUAL_UINT32(3, tokens.size());
+    TEST_ASSERT_EQUAL_STRING("one", tokens[0].c_str());
+    TEST_ASSERT_EQUAL_STRING("two", tokens[1].c_str());
+    TEST_ASSERT_EQUAL_STRING("three", tokens[2].c_str());
+}
+
+void test_trim_removes_outer_whitespace() {
+    const String trimmed = EZLog::trim("\t  spaced text \n");
+    TEST_ASSERT_EQUAL_STRING("spaced text", trimmed.c_str());
+}
+
+void test_format_number_adds_thousand_separators() {
+    TEST_ASSERT_EQUAL_STRING("12", EZLog::formatNumber(12).c_str());
+    TEST_ASSERT_EQUAL_STRING("1.234", EZLog::formatNumber(1234).c_str());
+    TEST_ASSERT_EQUAL_STRING("1.234.567", EZLog::formatNumber(1234567).c_str());
+}
+
+void test_shouldLog_uses_custom_elements() {
+    LoggingConfig config;
+    config.loglevel = Loglevel::WARN;
+    config.customLoggingElements = {
+        LoggingElement("Net", Loglevel::DEBUG),
+        LoggingElement("Root", std::vector<LoggingElement>{
+            LoggingElement("Service::Core", Loglevel::DEBUG),
+        }),
+    };
+
+    EZLog::init(config);
+
+    TEST_ASSERT_TRUE(EZLog::_shouldLog("Net::Client", Loglevel::INFO));
+    TEST_ASSERT_FALSE(EZLog::_shouldLog("Net::Client", Loglevel::VERBOSE));
+    TEST_ASSERT_TRUE(EZLog::_shouldLog("Service::Core::Init", Loglevel::DEBUG));
+    TEST_ASSERT_FALSE(EZLog::_shouldLog("Service::Core::Init", Loglevel::VERBOSE));
+}
+
+void test_shouldLog_falls_back_to_default_log_level() {
+    LoggingConfig config;
+    config.loglevel = Loglevel::WARN;
+    config.customLoggingElements.clear();
+
+    EZLog::init(config);
+
+    TEST_ASSERT_TRUE(EZLog::_shouldLog("Unknown::Thing", Loglevel::WARN));
+    TEST_ASSERT_FALSE(EZLog::_shouldLog("Unknown::Thing", Loglevel::INFO));
+}
+
+void test_shouldLog_override_logs_everything() {
+    LoggingConfig config;
+    config.overrideLogAll = true;
+    config.loglevel = Loglevel::ERROR;
+
+    EZLog::init(config);
+
+    TEST_ASSERT_TRUE(EZLog::_shouldLog("Anything", Loglevel::VERBOSE));
+}
+
+void setup() {
+    UNITY_BEGIN();
+    RUN_TEST(test_split_char_trims_whitespace);
+    RUN_TEST(test_split_string_delimiter);
+    RUN_TEST(test_trim_removes_outer_whitespace);
+    RUN_TEST(test_format_number_adds_thousand_separators);
+    RUN_TEST(test_shouldLog_uses_custom_elements);
+    RUN_TEST(test_shouldLog_falls_back_to_default_log_level);
+    RUN_TEST(test_shouldLog_override_logs_everything);
+    UNITY_END();
+}
+
+void loop() {}


### PR DESCRIPTION
### Motivation

- Prevent regressions in EZLog string utilities and filter logic by adding unit tests for core helper functions.
- Verify `EZLog::split`, `EZLog::trim`, and `EZLog::formatNumber` handle whitespace, delimiters and thousand separators correctly.
- Ensure `_shouldLog` filtering works with `LoggingConfig::customLoggingElements` and `overrideLogAll` behavior.

### Description

- Add test file `test/test_log_utils/test_log_utils.cpp` with Unity tests covering `EZLog::split`, `EZLog::trim`, `EZLog::formatNumber` and `_shouldLog` scenarios.
- Expose internals for testing by including `EZLog.h` with `#define private public` in the test file.
- Add a PlatformIO test environment `[env:esp32_test]` to `platformio.ini` configured with `test_framework = unity`, `test_filter = test_log_utils` and `test_build_project_src = true`.

### Testing

- Attempted to run the test suite with `pio test -e esp32_test`, but the command failed because the `pio` executable is not available in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965712f23fc832a8d4f1559d8430cf3)